### PR TITLE
Android compatibility

### DIFF
--- a/src/io/controls.cpp
+++ b/src/io/controls.cpp
@@ -66,8 +66,13 @@ Controls::Controls () {
 	keys[C_JUMP].key   = SDLK_SPACE;
 	keys[C_FIRE].key   = SDLK_LALT;
 	#endif
+	#ifdef ANDROID
+	keys[C_CHANGE].key = SDLK_RETURN;
+	keys[C_ENTER].key  = SDLK_SPACE;
+	#else
 	keys[C_CHANGE].key = SDLK_RCTRL;
 	keys[C_ENTER].key  = SDLK_RETURN;
+	#endif
 	keys[C_ESCAPE].key = SDLK_ESCAPE;
 	keys[C_STATS].key  = SDLK_F9;
 	keys[C_PAUSE].key  = SDLK_p;

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -449,11 +449,14 @@ int Level::loop (bool& menu, int& option, bool& message) {
 
 		}
 
-	} else {
+	}
+#if !(ANDROID)
+	else {
 
 		if (controls.wasCursorReleased()) menu = true;
 
 	}
+#endif
 
 	if (!multiplayer) paused = message || menu;
 


### PR DESCRIPTION
Commit @237c407 is pretty straightforward - it remaps two keys so they can be comfortably used on Android.
Speaking about @333eaf6, it's very easy to accidentally touch a touch-screen while playing and trigger pause in result, so the commit disables this behaviour on Android.