### PR TITLE
Network: use SO_NOSIGPIPE over MSG_NOSIGNAL on Darwin

### DIFF
--- a/src/io/network.cpp
+++ b/src/io/network.cpp
@@ -53,6 +53,9 @@
 		#include <errno.h>
 		#include <string.h>
 	#endif
+	#ifdef __APPLE__
+		#define MSG_NOSIGNAL SO_NOSIGPIPE
+	#endif
 #elif defined USE_SDL_NET
 	#include <arpa/inet.h>
 #endif


### PR DESCRIPTION
MSG_NOSIGNAL isn't defined on Darwin, but SO_NOSIGPIPE is sometimes used as an equivalent: http://www.microhowto.info/howto/prevent_a_process_from_terminating_when_writing_to_a_broken_pipe.html#idp30864

I haven't had the chance to test netplay, but this does fix the build.
