### PR TITLE
make: fix linking order and arguments passing in linking step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,10 @@ ifneq ($(MUSICLIB_LIBS),)
 endif
 
 LIBS += -lm
+LIBS += -lz
 
 OpenJazz: $(OBJS)
-	$(CXX) $(LDFLAGS) $(LIBS) -lz $(OBJS) -o OpenJazz
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o OpenJazz $(OBJS) $(LIBS)
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -Isrc -c $< -o $@


### PR DESCRIPTION
This fixes building with MinGW using the Makefile.