### PR TITLE
sound: fix array index to type int

### DIFF
--- a/src/io/sound.cpp
+++ b/src/io/sound.cpp
@@ -513,9 +513,9 @@ int loadSounds (const char *fileName) {
 /**
  * Resample sound clip data.
  */
-void resampleSound (char index, const char* name, int rate) {
+void resampleSound (int index, const char* name, int rate) {
 
-	int count, rsFactor, sample, sourceSample;
+	int count, rsFactor, sample;
 
     if (sounds[index].data) {
 

--- a/src/io/sound.h
+++ b/src/io/sound.h
@@ -100,7 +100,7 @@ EXTERN void stopMusic      ();
 EXTERN int  getMusicVolume ();
 EXTERN void setMusicVolume (int volume);
 EXTERN int  loadSounds     (const char *fileName);
-EXTERN void resampleSound  (char index, const char* name, int rate);
+EXTERN void resampleSound  (int index, const char* name, int rate);
 EXTERN void resampleSounds ();
 EXTERN void freeSounds     ();
 EXTERN void playSound      (char index);


### PR DESCRIPTION
This changes the first argument to resampleSound(), which is used as
an index to the sounds[] array, into an int. This fixes a lot of
"array subscript has type 'char'" compiler warnings. The variables
passed over as the first argument to resampleSound() in the rest of
the code are always od type int, anyway.

While at it, remove the "unused variable 'sourceSample'" warning as
well.