### PR TITLE
Symbian only

### DIFF
--- a/src/platforms/symbian.cpp
+++ b/src/platforms/symbian.cpp
@@ -11,6 +11,7 @@
  *
  */
 
+#ifdef __SYMBIAN32__
 
 #include <eikenv.h>
 #include <eikapp.h>
@@ -135,6 +136,8 @@ float sinf(float value)
 	Math::Sin(ret, value);
 	return ret;
 }
+
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This class is only needed when building Symbian port. In other cases, it can be ignored.