### PR TITLE
look in ~/.openjazz for data files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,7 +196,7 @@ void startUp (int argc, char *argv[]) {
 	#ifdef _WIN32
 	firstPath = new Path(firstPath, createString(getenv("HOME"), "\\"));
 	#else
-	firstPath = new Path(firstPath, createString(getenv("HOME"), "/."));
+	firstPath = new Path(firstPath, createString(getenv("HOME"), "/.openjazz/"));
 	#endif
 #endif
 


### PR DESCRIPTION
This patch is now applied in both Arch Linux and Debian, so it probably
makes sense to have it upstream.

Presumably no users will ever want to have their openjazz data stored
directly in their $HOME directory.