### PR TITLE
Don't show leading zeroes for the ammo count

### DIFF
--- a/src/jj1level/jj1levelframe.cpp
+++ b/src/jj1level/jj1levelframe.cpp
@@ -449,21 +449,13 @@ void JJ1Level::draw () {
 	// Show ammo
 	if (localPlayer->getAmmoType() == -1) {
 
+		// Draw "infinity" symbol
 		panelSmallFont->showString(":", 225, canvasH - 13);
 		panelSmallFont->showString(";", 233, canvasH - 13);
 
 	} else {
 
 		x = localPlayer->getAmmo();
-
-		// Trailing 0s
-		if (x < 100) {
-
-			panelSmallFont->showNumber(0, 229, canvasH - 13);
-			if (x < 10) panelSmallFont->showNumber(0, 237, canvasH - 13);
-
-		}
-
 		panelSmallFont->showNumber(x > 999? 999: x, 245, canvasH - 13);
 
 	}


### PR DESCRIPTION
This makes the ammo count easier to read, especially since the 0 and 8 digits look very close to each other at a distance (or for those with poor eyesight). It also makes it more obvious when you're running low on ammo. This is less accurate to the original, but I think usability wins over accuracy here :slightly_smiling_face:

I'd like to apply this change to other HUD elements as well, but I couldn't figure it out from a quick look at the source code.

## Preview

### Before

![image](https://user-images.githubusercontent.com/180032/109395388-6aaa4e00-792c-11eb-93c2-6b5a315dc6af.png)

### After

![image](https://user-images.githubusercontent.com/180032/109395366-42baea80-792c-11eb-9f88-cde1b3c082c8.png)