### PR TITLE
Set up continuous integration using GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,73 +1,108 @@
-name: Continuous integration
-on:
-  - push
-  - pull_request
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   linux-gcc:
-    name: Build (Ubuntu 18.04 x86_64, GCC)
-    # Test on a slightly old Linux distribution to ensure greater compatibility.
+    name: Build (Ubuntu 18.04 LTS x86_64, GCC)
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-
       - name: Install dependencies
         run: |
           sudo apt-get update -yqq
           sudo apt-get install -yqq build-essential libsdl1.2-dev
 
-      - name: Build OpenJazz
+      - name: Prepare Environment
         run: |
-          make -j$(nproc)
+          echo "SHORT_SHA=${GITHUB_SHA:0:10}" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build OpenJazz (normal)
+        run: |
+          make
           ls -l OpenJazz
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2.2.2
-        with:
-          name: openjazz-linux-glibc2.27-x86_64
-          path: OpenJazz
-
   linux-clang:
-    name: Build (Ubuntu 18.04 x86_64, Clang)
-    # Test on a slightly old Linux distribution to ensure greater compatibility.
+    name: Build (Ubuntu 18.04 LTS x86_64, Clang)
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-
       - name: Install dependencies
         run: |
           sudo apt-get update -yqq
           sudo apt-get install -yqq build-essential libsdl1.2-dev clang-10
 
-      - name: Build OpenJazz
+      - name: Prepare Environment
         run: |
-          CC=clang CXX=clang++ make -j$(nproc)
+          echo "SHORT_SHA=${GITHUB_SHA:0:10}" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build OpenJazz (slim)
+        run: |
+          export CXX=clang++
+          export CXXFLAGS="-Wall -O2 -g -ffunction-sections -fdata-sections"
+          export LDFLAGS="-Wl,--gc-sections"
+          make
           ls -l OpenJazz
+
+      - name: Prepare artifact
+        run: |
+          mkdir OJ-${SHORT_SHA}
+          pod2text -l unix/OpenJazz.6.pod Manual.txt
+          cp OpenJazz openjazz.000 README.md COPYING *.txt OJ-${SHORT_SHA}/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: openjazz-linux-glibc2.27-x86_64
+          path: OJ-*/
 
   windows-mingw-gcc:
     name: Build (Windows x86_64, MinGW, GCC)
     runs-on: windows-2019
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL
+          install: base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL dos2unix
+
+      - name: Prepare Environment
+        run: |
+          echo "SHORT_SHA=${GITHUB_SHA:0:10}" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Build OpenJazz
-        shell: msys2 {0}
         run: |
-          autoreconf -i
+          autoreconf -if
           ./configure --disable-dependency-tracking
-          make -j$(nproc)
-          ls -l OpenJazz.exe
+          make
+
+      - name: Prepare artifact
+        run: |
+          mkdir OJ-${SHORT_SHA}
+          pod2text -l unix/OpenJazz.6.pod Manual.txt
+          cp README.md README.txt
+          cp COPYING COPYING.txt
+          unix2dos *.txt
+          cp OpenJazz.exe openjazz.000 *.txt OJ-${SHORT_SHA}/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v2
         with:
           name: openjazz-windows-mingw-x86_64
-          path: OpenJazz.exe
+          path: OJ-*/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: Continuous integration
+on:
+  - push
+  - pull_request
+
+jobs:
+  linux-gcc:
+    name: Build (Ubuntu 18.04 x86_64, GCC)
+    # Test on a slightly old Linux distribution to ensure greater compatibility.
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yqq
+          sudo apt-get install -yqq build-essential libsdl1.2-dev
+
+      - name: Build OpenJazz
+        run: |
+          make -j$(nproc)
+          ls -l OpenJazz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          name: openjazz-linux-glibc2.27-x86_64
+          path: OpenJazz
+
+  linux-clang:
+    name: Build (Ubuntu 18.04 x86_64, Clang)
+    # Test on a slightly old Linux distribution to ensure greater compatibility.
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yqq
+          sudo apt-get install -yqq build-essential libsdl1.2-dev clang-10
+
+      - name: Build OpenJazz
+        run: |
+          CC=clang CXX=clang++ make -j$(nproc)
+          ls -l OpenJazz
+
+  windows-mingw-gcc:
+    name: Build (Windows x86_64, MinGW, GCC)
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL
+
+      - name: Build OpenJazz
+        shell: msys2 {0}
+        run: |
+          autoreconf -i
+          ./configure --disable-dependency-tracking
+          make -j$(nproc)
+          ls -l OpenJazz.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          name: openjazz-windows-mingw-x86_64
+          path: OpenJazz.exe

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ CPPFLAGS = -Isrc -DSCALE -Iext/scale2x -Iext/psmplug -Iext/miniz
 
 # Network support
 CXXFLAGS += -DUSE_SOCKETS
-# Needed under Windows
-#LIBS += -lws2_32
+ifeq ($(OS),Windows_NT)
+	# Only needed under Windows.
+	LIBS += -lws2_32
+endif
 
 # SDL
 CXXFLAGS += $(shell sdl-config --cflags)

--- a/src/io/network.cpp
+++ b/src/io/network.cpp
@@ -38,8 +38,9 @@
 		#include <winsock.h>
 		#define ioctl ioctlsocket
 		#define socklen_t int
-		#define EWOULDBLOCK WSAEWOULDBLOCK
-		#define MSG_NOSIGNAL 0
+		#ifndef EWOULDBLOCK
+			#define EWOULDBLOCK WSAEWOULDBLOCK
+		#endif
 	#else
 		#include <sys/types.h>
 		#include <sys/socket.h>
@@ -51,7 +52,7 @@
 		#include <errno.h>
 		#include <string.h>
 	#endif
-	#ifdef __APPLE__
+	#ifndef MSG_NOSIGNAL
 		#define MSG_NOSIGNAL 0
 	#endif
 	#ifdef _3DS


### PR DESCRIPTION
This allows distributing continuous binaries of OpenJazz for Windows (x86_64) and Linux (also x86_64). Compilation on Linux is tested with GCC and Clang on Ubuntu 18.04.

Note that I didn't package data files yet; I need to make a list of what needs to be installed alongside the binary. Hence this pull request being marked as a draft :slightly_smiling_face: 

This also fixes building with MinGW on Windows.