### PR TITLE
Initial SDL2 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ defaults:
     shell: bash
 
 jobs:
-  linux-gcc:
-    name: Build (Ubuntu 18.04 LTS x86_64, GCC)
+  linux-gcc-sdl1:
+    name: Build (Ubuntu 18.04 LTS x86_64, GCC, SDL 1.2)
     runs-on: ubuntu-18.04
     steps:
       - name: Install dependencies
@@ -34,11 +34,11 @@ jobs:
 
       - name: Build OpenJazz (normal)
         run: |
-          make
+          make SDLCONFIG=sdl-config
           ls -l OpenJazz
 
-  linux-clang:
-    name: Build (Ubuntu 18.04 LTS x86_64, Clang)
+  linux-clang-sdl1:
+    name: Build (Ubuntu 18.04 LTS x86_64, Clang, SDL 1.2)
     runs-on: ubuntu-18.04
     steps:
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
           export CXX=clang++
           export CXXFLAGS="-Wall -O2 -g -ffunction-sections -fdata-sections"
           export LDFLAGS="-Wl,--gc-sections"
-          make
+          make SDLCONFIG=sdl-config
           ls -l OpenJazz
 
       - name: Prepare artifact
@@ -75,6 +75,51 @@ jobs:
         with:
           name: openjazz-linux-glibc2.27-x86_64
           path: OJ-*/
+
+  linux-gcc-sdl2:
+    name: Build (Ubuntu 18.04 LTS x86_64, GCC, SDL2)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yqq
+          sudo apt-get install -yqq build-essential libsdl2-dev
+
+      - name: Prepare Environment
+        run: |
+          echo "SHORT_SHA=${GITHUB_SHA:0:10}" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build OpenJazz (normal)
+        run: |
+          make SDLCONFIG=sdl2-config
+          ls -l OpenJazz
+
+  linux-clang-sdl2:
+    name: Build (Ubuntu 18.04 LTS x86_64, Clang, SDL2)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yqq
+          sudo apt-get install -yqq build-essential libsdl2-dev clang-10 \
+            asciidoctor w3m
+
+      - name: Prepare Environment
+        run: |
+          echo "SHORT_SHA=${GITHUB_SHA:0:10}" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build OpenJazz (normal)
+        run: |
+          make SDLCONFIG=sdl2-config
+          ls -l OpenJazz
 
   windows-mingw-gcc:
     name: Build (Windows x86_64, MinGW, GCC)

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ ifeq ($(OS),Windows_NT)
 endif
 
 # SDL
-CXXFLAGS += $(shell sdl-config --cflags)
-LIBS += $(shell sdl-config --libs)
+SDLCONFIG ?= sdl-config
+CXXFLAGS += $(shell $(SDLCONFIG) --cflags)
+LIBS += $(shell $(SDLCONFIG) --libs)
 
 LIBS += -lm
 

--- a/src/io/gfx/font.cpp
+++ b/src/io/gfx/font.cpp
@@ -100,7 +100,7 @@ Font::Font (const char* fileName) {
 
 		} else characters[count] = createSurface(blank, 3, 1);
 
-		SDL_SetColorKey(characters[count], SDL_SRCCOLORKEY, 0);
+		enableColorKey(characters[count], 0);
 
 	}
 
@@ -174,7 +174,7 @@ Font::Font (unsigned char* pixels, bool big) {
 
 		characters[count] = createSurface(chrPixels, 8, lineHeight);
 
-		if (big) SDL_SetColorKey(characters[count], SDL_SRCCOLORKEY, 31);
+		if (big) enableColorKey(characters[count], 31);
 
 	}
 
@@ -289,7 +289,7 @@ Font::Font (bool bonus) {
 		pixels = file->loadPixels(width * height);
 
 		characters[count] = createSurface(pixels, width, height);
-		SDL_SetColorKey(characters[count], SDL_SRCCOLORKEY, 254);
+		enableColorKey(characters[count], 254);
 
 		delete[] pixels;
 
@@ -305,7 +305,7 @@ Font::Font (bool bonus) {
 	pixels = new unsigned char[3];
 	memset(pixels, 254, 3);
 	characters[nCharacters] = createSurface(pixels, 3, 1);
-	SDL_SetColorKey(characters[nCharacters], SDL_SRCCOLORKEY, 254);
+	enableColorKey(characters[nCharacters], 254);
 	delete[] pixels;
 
 
@@ -553,7 +553,7 @@ void Font::mapPalette (int start, int length, int newStart, int newLength) {
 			(count * newLength / length) + newStart;
 
 	for (count = 0; count < nCharacters; count++)
-		SDL_SetPalette(characters[count], SDL_LOGPAL, palette, start, length);
+		setLogicalPalette(characters[count], palette, start, length);
 
 	return;
 

--- a/src/io/gfx/sprite.cpp
+++ b/src/io/gfx/sprite.cpp
@@ -64,7 +64,7 @@ void Sprite::clearPixels () {
 
 	data = 0;
 	pixels = createSurface(&data, 1, 1);
-	SDL_SetColorKey(pixels, SDL_SRCCOLORKEY, 0);
+	enableColorKey(pixels, 0);
 
 	return;
 
@@ -94,7 +94,7 @@ void Sprite::setPixels (unsigned char *data, int width, int height, unsigned cha
 	if (pixels) SDL_FreeSurface(pixels);
 
 	pixels = createSurface(data, width, height);
-	SDL_SetColorKey(pixels, SDL_SRCCOLORKEY, key);
+	enableColorKey(pixels, key);
 
 	return;
 
@@ -158,7 +158,7 @@ int Sprite::getYOffset () {
  */
 void Sprite::setPalette (SDL_Color *palette, int start, int amount) {
 
-	SDL_SetPalette(pixels, SDL_LOGPAL, palette + start, start, amount);
+	setLogicalPalette(pixels, palette + start, start, amount);
 
 	return;
 
@@ -178,7 +178,7 @@ void Sprite::flashPalette (int index) {
 	for (count = 0; count < 256; count++)
 		palette[count].r = palette[count].g = palette[count].b = index;
 
-	SDL_SetPalette(pixels, SDL_LOGPAL, palette, 0, 256);
+	setLogicalPalette(pixels, palette, 0, 256);
 
 	return;
 
@@ -241,7 +241,7 @@ void Sprite::drawScaled (int x, int y, fixed scale) {
 	int dstX, dstY;
 	int srcX, srcY;
 
-	key = pixels->format->colorkey;
+	key = getColorKey(pixels);
 
 	fullWidth = FTOI(pixels->w * scale);
 	if (x < -(fullWidth >> 1)) return; // Off-screen

--- a/src/io/gfx/video.h
+++ b/src/io/gfx/video.h
@@ -94,6 +94,13 @@
 	#define NO_RESIZE
 
 	#define FULLSCREEN_FLAGS (SDL_FULLSCREEN | SDL_HWSURFACE)
+#elif SDL_VERSION_ATLEAST(2, 0, 0)
+	#define DEFAULT_SCREEN_WIDTH SW
+	#define DEFAULT_SCREEN_HEIGHT SH
+
+	#undef WINDOWED_FLAGS
+	#define WINDOWED_FLAGS (SDL_WINDOW_RESIZABLE)
+	#define FULLSCREEN_FLAGS (SDL_WINDOW_FULLSCREEN_DESKTOP)
 #else
 	#define DEFAULT_SCREEN_WIDTH SW
 	#define DEFAULT_SCREEN_HEIGHT SH
@@ -111,6 +118,12 @@
 class Video {
 
 	private:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		SDL_Window* window; ///< Output window
+		SDL_Renderer* renderer; ///< Output renderer
+		SDL_Texture* texture; ///< Output texture
+		SDL_Surface* textureSurface;
+#endif
 		SDL_Surface* screen; ///< Output surface
 
 		// Palettes
@@ -178,8 +191,11 @@ EXTERN Video video; ///< Video output
 
 // Functions
 
-EXTERN SDL_Surface*   createSurface  (unsigned char* pixels, int width, int height);
-EXTERN void           drawRect       (int x, int y, int width, int height, int index);
+EXTERN SDL_Surface*   createSurface     (unsigned char* pixels, int width, int height);
+EXTERN void           drawRect          (int x, int y, int width, int height, int index);
+EXTERN void           enableColorKey    (SDL_Surface* surface, unsigned int index);
+EXTERN unsigned int   getColorKey       (SDL_Surface* surface);
+EXTERN void           setLogicalPalette (SDL_Surface* surface, SDL_Color *palette, int start, int length);
 
 #endif
 

--- a/src/io/sound.cpp
+++ b/src/io/sound.cpp
@@ -28,6 +28,7 @@
 
 #include <SDL_audio.h>
 #include <psmplug.h>
+#include <cstring>
 
 #if defined(__SYMBIAN32__) || defined(_3DS) || defined(PSP) || defined(__vita__)
 	#define SOUND_FREQ 22050

--- a/src/jj1/level/jj1levelload.cpp
+++ b/src/jj1/level/jj1levelload.cpp
@@ -386,7 +386,7 @@ int JJ1Level::loadTiles (char* fileName) {
 	tiles = pos >> 10;
 
 	tileSet = createSurface(buffer, TTOI(1), TTOI(tiles));
-	SDL_SetColorKey(tileSet, SDL_SRCCOLORKEY, TKEY);
+	enableColorKey(tileSet, TKEY);
 
 	delete[] buffer;
 

--- a/src/jj2/level/jj2levelload.cpp
+++ b/src/jj2/level/jj2levelload.cpp
@@ -361,7 +361,7 @@ int JJ2Level::loadTiles (char* fileName) {
 	}
 
 	tileSet = createSurface(tileBuffer, TTOI(1), TTOI(tiles));
-	SDL_SetColorKey(tileSet, SDL_SRCCOLORKEY, 0);
+	enableColorKey(tileSet, 0);
 
 	// Flip tiles
 	for (count = 0; count < TTOI(tiles); count++) {
@@ -377,7 +377,7 @@ int JJ2Level::loadTiles (char* fileName) {
 	}
 
 	flippedTileSet = createSurface(tileBuffer, TTOI(1), TTOI(tiles));
-	SDL_SetColorKey(flippedTileSet, SDL_SRCCOLORKEY, 0);
+	enableColorKey(flippedTileSet, 0);
 
 	delete[] tileBuffer;
 

--- a/src/menu/gamemenu.cpp
+++ b/src/menu/gamemenu.cpp
@@ -49,7 +49,7 @@ GameMenu::GameMenu (File *file) {
 	// Load the difficulty graphics
 	file->loadPalette(menuPalette);
 	difficultyScreen = file->loadSurface(SW, SH);
-	SDL_SetColorKey(difficultyScreen, SDL_SRCCOLORKEY, 0);
+	enableColorKey(difficultyScreen, 0);
 
 	// Default difficulty setting
 	difficulty = 1;
@@ -493,7 +493,7 @@ int GameMenu::newGameEpisode (GameModeType mode) {
 		delete[] check;
 
 		if (exists[count]) video.restoreSurfacePalette(episodeScreens[count]);
-		else SDL_SetPalette(episodeScreens[count], SDL_LOGPAL, greyPalette, 0, 256);
+		else setLogicalPalette(episodeScreens[count], greyPalette, 0, 256);
 
 	}
 

--- a/src/menu/mainmenu.cpp
+++ b/src/menu/mainmenu.cpp
@@ -115,9 +115,9 @@ MainMenu::MainMenu () {
 
 	}
 
-	SDL_SetColorKey(background, SDL_SRCCOLORKEY, 0);
-	SDL_SetColorKey(highlight, SDL_SRCCOLORKEY, 0);
-	if (logo) SDL_SetColorKey(logo, SDL_SRCCOLORKEY, 28);
+	enableColorKey(background, 0);
+	enableColorKey(highlight, 0);
+	if (logo) enableColorKey(logo, 28);
 
 	gameMenu = new GameMenu(file);
 

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -132,7 +132,7 @@ SetupOptions Setup::load () {
 
 	// Read controls
 	for (count = 0; count < CONTROLS - 4; count++)
-		controls.setKey(count, (SDLKey)(file->loadInt()));
+		controls.setKey(count, file->loadInt());
 
 	for (count = 0; count < CONTROLS; count++)
 		controls.setButton(count, file->loadInt());


### PR DESCRIPTION
This works for me, however there are a couple of caveats that make SDL1 preferable for most cases:
- SDL2 doesn't officially support hardware palettes yet, so conversion to true colour is always done in software.
- The keycode values are currently written directly into the configuration file, but IIRC don't have the same values between SDL1 and SDL2, which may affect compatibility.

Fixes #33 and fixes #63, although this PR isn't based on any of the previous attempts.