### PR TITLE
Fix non-Linux UNIX-y builds

### DIFF
--- a/ext/psmplug/stdafx.h
+++ b/ext/psmplug/stdafx.h
@@ -46,7 +46,10 @@ inline void ProcessPlugins(int n) {}
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
+#ifdef __linux__
 #include <malloc.h>
+#endif
 
 typedef int8_t CHAR;
 typedef uint8_t UCHAR;


### PR DESCRIPTION
`malloc.h` is a Linux-specific header, so without `ifdef`-ing it, it breaks Mac (and presumably BSD) builds.