### PR TITLE
fix: remove usage of malloc.h

### DIFF
--- a/ext/psmplug/stdafx.h
+++ b/ext/psmplug/stdafx.h
@@ -21,7 +21,6 @@
 #include <windowsx.h>
 #include <mmsystem.h>
 #include <stdio.h>
-#include <malloc.h>
 #include <stdint.h>
 
 #define srandom(_seed)  srand(_seed)
@@ -46,7 +45,6 @@ inline void ProcessPlugins(int n) {}
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
 
 typedef int8_t CHAR;
 typedef uint8_t UCHAR;


### PR DESCRIPTION
As identified in https://github.com/Homebrew/homebrew-core/pull/152682, OpenJazz doesn't build on macOS with these malloc references.

https://stackoverflow.com/a/56463133 says they're not standards compliant, so it should probably be removed.