### PR TITLE
Added Apple platform code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,10 @@ elseif(HAIKU)
 	target_sources(OpenJazz PRIVATE
 		src/platforms/haiku.cpp
 		src/platforms/haiku.h)
+elseif(APPLE)
+	target_sources(OpenJazz PRIVATE
+		src/platforms/apple.cpp
+		src/platforms/apple.h)
 elseif(UNIX)
 	target_sources(OpenJazz PRIVATE
 		src/platforms/xdg.cpp

--- a/src/platforms/apple.cpp
+++ b/src/platforms/apple.cpp
@@ -1,0 +1,38 @@
+
+/**
+ *
+ * @file apple.cpp
+ *
+ * Part of the OpenJazz project
+ *
+ * @par Licence:
+ * Copyright (c) 2015-2023 Carsten Teibes
+ *
+ * OpenJazz is distributed under the terms of
+ * the GNU General Public License, version 2.0
+ *
+ */
+
+#include "apple.h"
+
+#ifdef __APPLE__
+
+#include "TargetConditionals.h"
+
+#include <SDL.h>
+#include "util.h"
+#include "io/file.h"
+
+void APPLE_AddGamePaths() {
+#ifdef TARGET_OS_MAC
+	gamePaths.add(createString(SDL_GetPrefPath("", "OpenJazz")), PATH_TYPE_SYSTEM|PATH_TYPE_GAME|PATH_TYPE_CONFIG);
+#endif
+}
+
+void APPLE_ErrorNoDatafiles() {
+#ifdef TARGET_OS_MAC
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenJazz", createString("Unable to find game data files.\n\nPut the data into the folder: ", SDL_GetPrefPath("", "OpenJazz")), 0);
+#endif
+}
+
+#endif

--- a/src/platforms/apple.h
+++ b/src/platforms/apple.h
@@ -1,0 +1,28 @@
+
+/**
+ *
+ * @file apple.h
+ *
+ * Part of the OpenJazz project
+ *
+ * @par Licence:
+ * Copyright (c) 2015-2023 Carsten Teibes
+ *
+ * OpenJazz is distributed under the terms of
+ * the GNU General Public License, version 2.0
+ *
+ */
+
+
+#ifndef _APPLE_H
+#define _APPLE_H
+
+#ifdef __APPLE__
+
+void APPLE_AddGamePaths();
+
+void APPLE_ErrorNoDatafiles();
+
+#endif
+
+#endif

--- a/src/platforms/platforms.h
+++ b/src/platforms/platforms.h
@@ -26,6 +26,7 @@
 #include "riscos.h"
 #include "symbian.h"
 #include "xdg.h"
+#include "apple.h"
 
 inline void PLATFORM_Init() {
 #ifdef PSP
@@ -87,6 +88,10 @@ inline void PLATFORM_AddGamePaths() {
 	XDG_AddGamePaths();
 	#endif
 #endif
+
+#ifdef __APPLE__
+	APPLE_AddGamePaths();
+#endif
 }
 
 inline void PLATFORM_ErrorNoDatafiles() {
@@ -100,6 +105,10 @@ inline void PLATFORM_ErrorNoDatafiles() {
 
 #ifdef _3DS
 	N3DS_ErrorNoDatafiles();
+#endif
+
+#ifdef __APPLE__
+	APPLE_ErrorNoDatafiles();
 #endif
 }
 


### PR DESCRIPTION
This adds the ability for the game to pull data from Application Support, necessary for being able to run in a bundle on macOS. I wrapped the macOS-specific code in conditionals so that if in the future anyone wanted to add iOS or tvOS support the scaffolding is there.

I maintain a build of OpenJazz for [Mac Source Ports](https://www.macsourceports.com/) and this will allow me to use the latest project code instead of relying on a fork.