### PR TITLE
Fixed joystick events bug

### DIFF
--- a/src/menu/setupmenu.cpp
+++ b/src/menu/setupmenu.cpp
@@ -135,11 +135,15 @@ int SetupMenu::setupJoystick () {
 	int x, y;
 
 	int progress = 0;
-
+	int lastcontrol = -1;
+	
 	while (true) {
 
 		int control = loop(SET_JOYSTICK_LOOP);
-
+		if (control == lastcontrol) {
+			continue;
+		}
+		
 		if (control == E_QUIT) return E_QUIT;
 
 		switch (control & 0xF00) {
@@ -170,6 +174,7 @@ int SetupMenu::setupJoystick () {
 
 				}
 
+				lastcontrol = control;
 				break;
 
 			case JOYSTICKANEG:
@@ -197,7 +202,7 @@ int SetupMenu::setupJoystick () {
 					}
 
 				}
-
+				lastcontrol = control;
 				break;
 
 			case JOYSTICKAPOS:
@@ -225,7 +230,8 @@ int SetupMenu::setupJoystick () {
 					}
 
 				}
-
+				
+				lastcontrol = control;
 				break;
 
 			case JOYSTICKHUP:
@@ -264,7 +270,7 @@ int SetupMenu::setupJoystick () {
 					}
 
 				}
-
+				lastcontrol = control;
 				break;
 
 		}


### PR DESCRIPTION
This fixes https://github.com/AlisterT/openjazz/issues/85 by using a simple detection method to stop duplicate events from filling up the control settings. Tested only on Linux but is platform independent so should work everywhere. 